### PR TITLE
Resolved crash for iOS 11

### DIFF
--- a/UIForLumberjack/UIForLumberjack.m
+++ b/UIForLumberjack/UIForLumberjack.m
@@ -69,6 +69,8 @@ NSString *const LogCellReuseIdentifier = @"LogCell";
     dispatch_async(dispatch_get_main_queue(), ^{
         [_messages addObject:logMessage];
         
+        if (_tableView.superview == nil) { return; }
+        
         BOOL scroll = NO;
         if(_tableView.contentOffset.y + _tableView.bounds.size.height >= _tableView.contentSize.height)
             scroll = YES;


### PR DESCRIPTION
It fixes the iOS 11 crash. 

Crash occurs when you are logging with `logMessage` and your tableview is not yet added to the view. 
